### PR TITLE
fix: detekt issue part-2

### DIFF
--- a/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
+++ b/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
@@ -91,6 +91,12 @@ class NoteListViewModel(
             }
         }
     }
+
+    fun showError(errStr: String) {
+        viewModelScope.launch {
+            _snackBarEvent.emit(value = errStr)
+        }
+    }
 }
 
 sealed class NoteListUiState {


### PR DESCRIPTION
- Extracted composable functions from `NoteListScreen` for better readability and reusability.
- Added `showError` function to `NoteListViewModel` to emit error messages to be displayed in a Snackbar.
- Replaced `Toast` with `Snackbar`  for displaying error messages in `NoteListScreen`.