### PR TITLE
feat: Implement search functionality in note list

### DIFF
--- a/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepository.kt
+++ b/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepository.kt
@@ -1,11 +1,12 @@
 package com.noteapp.data.repository
 
 import com.noteapp.domain.model.Note
+import com.noteapp.util.NoteConstant.LONG_FIFTY
 import kotlinx.coroutines.flow.Flow
 
 interface FirestoreDBRepository {
 
-    suspend fun observeNoteList(): Flow<List<Note>>
+    suspend fun searchNoteByTitle(userId: String? = null, query: String, limit: Long = LONG_FIFTY): Flow<List<Note>>
 
     suspend fun insertNote(note: Note): String
 

--- a/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepositoryImpl.kt
+++ b/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepositoryImpl.kt
@@ -1,13 +1,14 @@
 package com.noteapp.data.repository
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.snapshots
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.toObject
 import com.noteapp.domain.model.Note
 import com.noteapp.util.NoteConstant.NOTES
-import com.noteapp.util.NoteConstant.TIMESTAMP
+import com.noteapp.util.NoteConstant.TITLE
+import com.noteapp.util.NoteConstant.USER_ID
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -15,13 +16,29 @@ class FirestoreDBRepositoryImpl @Inject constructor(private val firestore: Fireb
 
     private val noteCollection = firestore.collection(NOTES)
 
-    override suspend fun observeNoteList(): Flow<List<Note>> {
-        return noteCollection
-            .orderBy(TIMESTAMP)
-            .snapshots()
-            .map { querySnapshot ->
-                querySnapshot.documents.mapNotNull { it.toObject<Note>() }
+    override suspend fun searchNoteByTitle(userId: String?, query: String, limit: Long): Flow<List<Note>> {
+        return flow {
+            var ref: Query = noteCollection
+            /*
+            userId is to identify whose notes we are fetching,
+            if given null, it will fetch all the notes irrespective of user.
+            Pass userId to avoid any user conflicts
+            */
+            if (!userId.isNullOrEmpty()) {
+                ref = ref.whereEqualTo(USER_ID, userId)
             }
+            val ordered = ref.orderBy(TITLE)
+            val snap = if (query.isBlank()) {
+                ordered.limit(limit).get().await()
+            } else {
+                val end = query + '\uf8ff'
+                ordered.startAt(query).endAt(end).limit(limit).get().await()
+            }
+            val list = snap.documents.mapNotNull {
+                it.toObject(Note::class.java)?.copy(id = it.id)
+            }
+            emit(value = list)
+        }
     }
 
     override suspend fun insertNote(note: Note): String {

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -97,7 +97,7 @@ fun NoteListScreen(navController: NavController,
 
     Scaffold(
         topBar = {
-            NoteListTopBar(hasNotes = hasNotes) {
+            NoteListTopBar(viewModel = viewModel, hasNotes = hasNotes) {
                 showDeleteAllNotesDialog = true
             }
         },
@@ -166,16 +166,17 @@ fun ShowSnackBarMsg(
 // Note topbar
 @OptIn(markerClass = [ExperimentalMaterial3Api::class])
 @Composable
-fun NoteListTopBar(hasNotes: Boolean, onDeleteAllNotesClick:() -> Unit) {
-
-    var searchQuery by remember { mutableStateOf(value = EMPTY_STRING) }
-
+fun NoteListTopBar(
+    viewModel: NoteListViewModel,
+    hasNotes: Boolean,
+    onDeleteAllNotesClick:() -> Unit
+) {
     TopAppBar(
         title = {
             SearchBar(
-                searchQuery = searchQuery,
+                searchQuery = viewModel.searchQueryToShowInSearchBox,
                 onQueryChange = { newQuery ->
-                    searchQuery = newQuery
+                    viewModel.onQueryChanged(newQuery = newQuery)
                 }
             )
         },

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -1,24 +1,33 @@
 package com.noteapp.presentation.ui.screen
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,8 +38,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.firestore.FirebaseFirestore
@@ -45,6 +60,7 @@ import com.noteapp.presentation.viewmodel.NoteListUiState
 import com.noteapp.presentation.viewmodel.NoteListViewModel
 import com.noteapp.preview.FakeNoteDao
 import com.noteapp.util.NoteConstant.EIGHT
+import com.noteapp.util.NoteConstant.EMPTY_STRING
 import com.noteapp.util.NoteConstant.NOTE_ACTION
 
 @OptIn(markerClass = [ExperimentalMaterial3Api::class])
@@ -151,14 +167,16 @@ fun ShowSnackBarMsg(
 @OptIn(markerClass = [ExperimentalMaterial3Api::class])
 @Composable
 fun NoteListTopBar(hasNotes: Boolean, onDeleteAllNotesClick:() -> Unit) {
+
+    var searchQuery by remember { mutableStateOf(value = EMPTY_STRING) }
+
     TopAppBar(
         title = {
-            Text(text = stringResource(id = R.string.note_list_title))
-        },
-        navigationIcon = {
-            Icon(
-                imageVector = Icons.Default.Home,
-                contentDescription = stringResource(id = R.string.home)
+            SearchBar(
+                searchQuery = searchQuery,
+                onQueryChange = { newQuery ->
+                    searchQuery = newQuery
+                }
             )
         },
         actions = {
@@ -170,6 +188,65 @@ fun NoteListTopBar(hasNotes: Boolean, onDeleteAllNotesClick:() -> Unit) {
                 }
             }
         }
+    )
+}
+
+@Composable
+fun SearchBar(searchQuery: String, onQueryChange:(String) -> Unit) {
+
+    val textStyle = MaterialTheme.typography.bodyLarge
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
+    OutlinedTextField(
+        value = searchQuery,
+        onValueChange = { newQuery ->
+            onQueryChange(newQuery)
+        },
+        singleLine = true,
+        textStyle = textStyle,
+        placeholder = {
+            Text(text = stringResource(id = R.string.search_notes), style = textStyle)
+        },
+        keyboardOptions = KeyboardOptions(
+            imeAction = ImeAction.Search,
+            capitalization = KeyboardCapitalization.Sentences
+        ),
+        keyboardActions = KeyboardActions(
+            onSearch = {
+                keyboardController?.hide()
+                focusManager.clearFocus()
+            }
+        ),
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = stringResource(id = R.string.search)
+            )
+        },
+        trailingIcon = {
+            if (searchQuery.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange(EMPTY_STRING) }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(id = R.string.clear)
+                    )
+                }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = Color.LightGray,
+                shape = RoundedCornerShape(size = 32.dp)
+            ),
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = Color.Transparent,
+            unfocusedContainerColor = Color.Transparent,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        )
     )
 }
 
@@ -200,17 +277,26 @@ fun NoteShimmer() {
 // Note list success
 @Composable
 fun NoteList(noteList: List<Note>, onNoteClick:(String) -> Unit, onDeleteNote:(String) -> Unit) {
-    LazyColumn {
-        items(items = noteList) { note ->
-            NoteItem(
-                note = note,
-                onNoteClick = { noteId ->
-                    onNoteClick(noteId)
-                },
-                onDeleteNoteClick = {
-                    onDeleteNote(note.id)
-                }
-            )
+    Column {
+        Text(
+            modifier = Modifier.padding(start = 24.dp, top = 24.dp),
+            style = MaterialTheme.typography.headlineSmall,
+            text = stringResource(id = R.string.note_list_title)
+        )
+        LazyColumn(
+            modifier = Modifier.padding(top = 16.dp)
+        ) {
+            items(items = noteList) { note ->
+                NoteItem(
+                    note = note,
+                    onNoteClick = { noteId ->
+                        onNoteClick(noteId)
+                    },
+                    onDeleteNoteClick = {
+                        onDeleteNote(note.id)
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/noteapp/util/NoteConstant.kt
+++ b/app/src/main/java/com/noteapp/util/NoteConstant.kt
@@ -20,7 +20,7 @@ object NoteConstant {
     const val TWO = 2
     const val THREE = 3
     const val EIGHT = 8
-    const val THOUSAND = 1000
+    const val ONE_THOUSAND = 1000
     // Negative
     const val MINUS_TWO = -2
     // Float
@@ -28,12 +28,14 @@ object NoteConstant {
     const val FLOAT_POINT_TWO = 0.2f
     const val FLOAT_POINT_SIX = 0.6f
     // Long
-    const val LONG_THREE_THOUSAND = 3000L
+    const val LONG_FIFTY = 50L
+    const val LONG_FOUR_HUNDRED = 400L
 
     // Rest
+    const val TITLE = "title"
     const val EMPTY_STRING = ""
     const val NOTE_ID = "noteId"
-    const val TIMESTAMP = "timestamp"
+    const val USER_ID = "userId"
     const val NOTE_ACTION = "note_action"
     const val DD_MMM_YY_HHMM_A = "dd-MMM-yy hh:mm a"
 

--- a/app/src/main/java/com/noteapp/util/NoteExtension.kt
+++ b/app/src/main/java/com/noteapp/util/NoteExtension.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.IntSize
 import com.noteapp.util.NoteConstant.FLOAT_POINT_SIX
 import com.noteapp.util.NoteConstant.FLOAT_POINT_TWO
 import com.noteapp.util.NoteConstant.MINUS_TWO
-import com.noteapp.util.NoteConstant.THOUSAND
+import com.noteapp.util.NoteConstant.ONE_THOUSAND
 import com.noteapp.util.NoteConstant.TWO
 
 fun Modifier.shimmerEffect(): Modifier = composed {
@@ -30,7 +30,7 @@ fun Modifier.shimmerEffect(): Modifier = composed {
         initialValue = MINUS_TWO * size.width.toFloat(),
         targetValue = TWO * size.width.toFloat(),
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = THOUSAND)
+            animation = tween(durationMillis = ONE_THOUSAND)
         )
     )
     background(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,10 +3,13 @@
 
     <!--Note List Screen-->
     <string name="home">Home</string>
+    <string name="clear">Clear</string>
     <string name="delete">Delete</string>
+    <string name="search">Search</string>
     <string name="add_note">Add Note</string>
     <string name="note_list_title">Notes</string>
     <string name="delete_all">Delete All</string>
+    <string name="search_notes">Search notes</string>
     <string name="delete_all_notes">Delete All Notes</string>
     <string name="note_added">Note added successfully!</string>
     <string name="no_notes_available">No Notes Available</string>


### PR DESCRIPTION
This commit introduces a search bar in the `NoteListScreen` to allow users to search through their notes.

Key changes:
- Integrated a `SearchBar` Composable into the `NoteListTopBar`.
- The `SearchBar`  includes:
  - An `OutlinedTextField` for text input.
  - Leading Search icon.
  - Trailing Close icon to clear the search query (appears when text is entered).
  - Keyboard actions to hide the keyboard and clear focus on search.
- The Notes title is now displayed as a separate `Text`  Composable above the `LazyColumn` containing the note items.