### PR TITLE
Refactor: Improve Firestore note searching and fetching

### DIFF
--- a/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepository.kt
+++ b/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepository.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface FirestoreDBRepository {
 
+    suspend fun getAllNotes(userId: String? = null, limit: Long = LONG_FIFTY): Flow<List<Note>>
+
     suspend fun searchNoteByTitle(userId: String? = null, query: String, limit: Long = LONG_FIFTY): Flow<List<Note>>
 
     suspend fun insertNote(note: Note): String

--- a/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepositoryImpl.kt
+++ b/app/src/main/java/com/noteapp/data/repository/FirestoreDBRepositoryImpl.kt
@@ -5,10 +5,14 @@ import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.toObject
 import com.noteapp.domain.model.Note
 import com.noteapp.util.NoteConstant.NOTES
-import com.noteapp.util.NoteConstant.TITLE
+import com.noteapp.util.NoteConstant.TIMESTAMP
+import com.noteapp.util.NoteConstant.TITLE_LOWER
 import com.noteapp.util.NoteConstant.USER_ID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -16,8 +20,8 @@ class FirestoreDBRepositoryImpl @Inject constructor(private val firestore: Fireb
 
     private val noteCollection = firestore.collection(NOTES)
 
-    override suspend fun searchNoteByTitle(userId: String?, query: String, limit: Long): Flow<List<Note>> {
-        return flow {
+    override suspend fun getAllNotes(userId: String?, limit: Long): Flow<List<Note>> {
+        return callbackFlow {
             var ref: Query = noteCollection
             /*
             userId is to identify whose notes we are fetching,
@@ -27,18 +31,59 @@ class FirestoreDBRepositoryImpl @Inject constructor(private val firestore: Fireb
             if (!userId.isNullOrEmpty()) {
                 ref = ref.whereEqualTo(USER_ID, userId)
             }
-            val ordered = ref.orderBy(TITLE)
-            val snap = if (query.isBlank()) {
-                ordered.limit(limit).get().await()
+            ref = ref
+                .orderBy(TIMESTAMP, Query.Direction.DESCENDING)
+                .limit(limit)
+            val reg = ref.addSnapshotListener { snap, err ->
+                if (err != null) {
+                    close(cause = err)
+                    return@addSnapshotListener
+                }
+                val list = snap?.documents
+                    ?.mapNotNull { it.toObject(Note::class.java)?.copy(id = it.id) }
+                    ?: emptyList()
+                trySend(element = list).isSuccess
+            }
+            awaitClose {
+                reg.remove()
+            }
+        }.flowOn(context = Dispatchers.IO)
+    }
+
+    override suspend fun searchNoteByTitle(userId: String?, query: String, limit: Long): Flow<List<Note>> {
+        return callbackFlow {
+            var ref: Query = noteCollection
+            /*
+            userId is to identify whose notes we are fetching,
+            if given null, it will fetch all the notes irrespective of user.
+            Pass userId to avoid any user conflicts
+            */
+            if (!userId.isNullOrEmpty()) {
+                ref = ref.whereEqualTo(USER_ID, userId)
+            }
+            val ordered = ref.orderBy(TITLE_LOWER)
+            val queryLower = query.lowercase()
+            ref = if (queryLower.isBlank()) {
+                ordered.limit(limit)
             } else {
-                val end = query + '\uf8ff'
-                ordered.startAt(query).endAt(end).limit(limit).get().await()
+                val end = queryLower + '\uf8ff'
+                ordered.startAt(queryLower).endAt(end).limit(limit)
             }
-            val list = snap.documents.mapNotNull {
-                it.toObject(Note::class.java)?.copy(id = it.id)
+
+            val reg = ref.addSnapshotListener { snap, err ->
+                if (err != null) {
+                    close(cause = err)
+                    return@addSnapshotListener
+                }
+                val list = snap?.documents
+                    ?.mapNotNull { it.toObject(Note::class.java)?.copy(id = it.id) }
+                    ?: emptyList()
+                trySend(element = list).isSuccess
             }
-            emit(value = list)
-        }
+            awaitClose {
+                reg.remove()
+            }
+        }.flowOn(context = Dispatchers.IO)
     }
 
     override suspend fun insertNote(note: Note): String {

--- a/app/src/main/java/com/noteapp/domain/model/Note.kt
+++ b/app/src/main/java/com/noteapp/domain/model/Note.kt
@@ -1,11 +1,18 @@
 package com.noteapp.domain.model
 
+import com.google.firebase.firestore.PropertyName
 import com.noteapp.util.NoteConstant.EMPTY_STRING
+import com.noteapp.util.NoteConstant.TITLE_LOWER
 import com.noteapp.util.formatTimestamp
 
 data class Note(
     var id: String = EMPTY_STRING,
     var title: String = EMPTY_STRING,
+
+    @get:PropertyName(value = TITLE_LOWER)
+    @set:PropertyName(value = TITLE_LOWER)
+    var titleLower: String = EMPTY_STRING, // To be used for searching
+
     var description: String = EMPTY_STRING,
     var timestamp: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/noteapp/presentation/viewmodel/AddEditNoteViewModel.kt
+++ b/app/src/main/java/com/noteapp/presentation/viewmodel/AddEditNoteViewModel.kt
@@ -77,10 +77,19 @@ class AddEditNoteViewModel(
                 val title = noteTitle.trim()
                 val desc = noteDesc.trim()
                 if (!noteId.isNullOrEmpty()) { // Update operation
-                    val note = Note(id = noteId, title = title, description = desc)
+                    val note = Note(
+                        id = noteId,
+                        title = title,
+                        titleLower = title.lowercase(),
+                        description = desc
+                    )
                     firestoreRepository.updateNote(note)
                 } else { // Insert operation
-                    val note = Note(title = title, description = desc)
+                    val note = Note(
+                        title = title,
+                        titleLower = title.lowercase(),
+                        description = desc
+                    )
                     firestoreRepository.insertNote(note)
                 }
                 goBack()

--- a/app/src/main/java/com/noteapp/util/NoteConstant.kt
+++ b/app/src/main/java/com/noteapp/util/NoteConstant.kt
@@ -32,10 +32,11 @@ object NoteConstant {
     const val LONG_FOUR_HUNDRED = 400L
 
     // Rest
-    const val TITLE = "title"
     const val EMPTY_STRING = ""
     const val NOTE_ID = "noteId"
     const val USER_ID = "userId"
+    const val TIMESTAMP = "timestamp"
+    const val TITLE_LOWER = "title_lower"
     const val NOTE_ACTION = "note_action"
     const val DD_MMM_YY_HHMM_A = "dd-MMM-yy hh:mm a"
 


### PR DESCRIPTION
This commit introduces several improvements to how notes are fetched and searched in Firestore:

- **Added `getAllNotes` function:** A new function in `FirestoreDBRepository` and its implementation to fetch all notes, ordered by timestamp.
- **Improved search functionality:**
    - Modified `searchNoteByTitle` to use `callbackFlow` for real-time updates.
    - Added a `titleLower` field to the `Note` data class. This field stores the lowercase version of the title and is used for case-insensitive searching in Firestore.
    - Updated `AddEditNoteViewModel` to populate `titleLower` when inserting or updating notes.
- **Refactored `NoteListViewModel`:**
    - Leveraged `flatMapLatest` to switch between fetching all notes (when search query is empty) and searching notes based on the query.
    - Removed the explicit `searchNoteJob` as `flatMapLatest` handles cancellation and restarting of flows.
- **Constants:** Added `TIMESTAMP` and `TITLE_LOWER` constants in `NoteConstant.kt`.