### PR TITLE
fix: Refactor list/grid view toggle icon

### DIFF
--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -107,6 +107,7 @@ fun NoteListScreen(navController: NavController,
                     NoteShimmer()
                 }
                 is NoteListUiState.Success -> {
+
                     val noteList = (uiState as NoteListUiState.Success).noteList
                     if(noteList.isNotEmpty()) {
                         NoteListSuccess(

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -1,6 +1,7 @@
 package com.noteapp.presentation.ui.screen
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -224,6 +226,7 @@ fun SearchBar(
         },
         modifier = Modifier
             .fillMaxWidth()
+            .padding(end = 16.dp)
             .border(
                 width = 1.dp,
                 color = Color.LightGray,
@@ -283,24 +286,24 @@ fun NoteListSuccess(
                 style = MaterialTheme.typography.headlineSmall,
                 text = stringResource(id = R.string.note_list_title)
             )
-            IconButton(onClick = {
-                onNoteListViewChanged(!isGridView)
-            }) {
-                val icon = if (isGridView){
+            Icon(
+                painter = if (isGridView) {
                     painterResource(id = R.drawable.grid_view)
-                } else {
+                } else{
                     painterResource(id = R.drawable.list_view)
-                }
-                val desc = if (isGridView) {
+                },
+                contentDescription = if (isGridView) {
                     stringResource(id = R.string.switch_to_grid_view)
-                } else {
+                } else{
                     stringResource(id = R.string.switch_to_list_view)
-                }
-                Icon(
-                    painter = icon,
-                    contentDescription = desc
-                )
-            }
+                },
+                modifier = Modifier
+                    .size(size = 24.dp)
+                    .clickable {
+                        onNoteListViewChanged(!isGridView)
+                    }
+                    .padding(all = 0.dp) // ensure no extra padding
+            )
         }
         if(isGridView) {
             NoteListGridAdaptive(

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -106,7 +106,6 @@ fun NoteListScreen(navController: NavController,
                 NoteListUiState.Loading -> {
                     NoteShimmer()
                 }
-
                 is NoteListUiState.Success -> {
                     val noteList = (uiState as NoteListUiState.Success).noteList
                     if(noteList.isNotEmpty()) {

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -278,7 +278,7 @@ fun NoteListSuccess(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 24.dp, top = 24.dp, end = 24.dp),
+                .padding(start = 24.dp, top = 24.dp, end = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -288,9 +288,9 @@ fun NoteListSuccess(
             )
             Icon(
                 painter = if (isGridView) {
-                    painterResource(id = R.drawable.grid_view)
-                } else{
                     painterResource(id = R.drawable.list_view)
+                } else{
+                    painterResource(id = R.drawable.grid_view)
                 },
                 contentDescription = if (isGridView) {
                     stringResource(id = R.string.switch_to_grid_view)
@@ -298,11 +298,11 @@ fun NoteListSuccess(
                     stringResource(id = R.string.switch_to_list_view)
                 },
                 modifier = Modifier
-                    .size(size = 24.dp)
+                    .size(size = 48.dp)
                     .clickable {
                         onNoteListViewChanged(!isGridView)
                     }
-                    .padding(all = 0.dp) // ensure no extra padding
+                    .padding(all = 12.dp) // ensure no extra padding
             )
         }
         if(isGridView) {


### PR DESCRIPTION
This commit refactors the view toggle button on the `NoteListScreen`.

- Replaces the `IconButton` with a clickable `Icon` for a more direct implementation.
- Adjusts padding on the search bar and the new toggle icon for better alignment and spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted search bar spacing with added end padding for cleaner layout.
  * Added internal padding to the view toggle icon to prevent layout shifts.
  * Reduced row end padding for tighter alignment in the note list.

* **Refactor**
  * Replaced the toggle control with a single, consistently sized icon that responds directly to taps for view switching.
  * Simplified icon rendering and content descriptions for improved accessibility and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->