### PR TITLE
feat: Implement pull-to-refresh for note list

### DIFF
--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,6 +54,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.firestore.FirebaseFirestore
@@ -86,8 +86,8 @@ fun NoteListScreen(navController: NavController,
         snackBarHostState = snackBarHostState
     )
 
-    val uiState by viewModel.uiState.collectAsState()
-    val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     var isGridView by rememberSaveable { mutableStateOf(value = false) }
 
     LaunchedEffect(key1 = Unit) {

--- a/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
+++ b/app/src/main/java/com/noteapp/presentation/ui/screen/NoteListScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -86,7 +87,12 @@ fun NoteListScreen(navController: NavController,
     )
 
     val uiState by viewModel.uiState.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
     var isGridView by rememberSaveable { mutableStateOf(value = false) }
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.observeNoteList() // Start continuous listening
+    }
 
     Scaffold(
         topBar = {
@@ -107,10 +113,10 @@ fun NoteListScreen(navController: NavController,
                     NoteShimmer()
                 }
                 is NoteListUiState.Success -> {
-
                     val noteList = (uiState as NoteListUiState.Success).noteList
                     if(noteList.isNotEmpty()) {
                         NoteListSuccess(
+                            isRefreshing = isRefreshing,
                             noteList = noteList,
                             isGridView = isGridView,
                             onNoteListViewChanged = { changedNoteListView ->
@@ -119,6 +125,9 @@ fun NoteListScreen(navController: NavController,
                             onNoteClick = onNoteClick,
                             onDeleteNote = { noteId ->
                                 viewModel.deleteNote(noteId)
+                            },
+                            onRefreshNoteList = {
+                                viewModel.refreshNoteList()
                             }
                         )
                     } else {
@@ -252,13 +261,16 @@ fun NoteShimmer() {
 }
 
 // Note list success
+@OptIn(markerClass = [ExperimentalMaterial3Api::class])
 @Composable
 fun NoteListSuccess(
+    isRefreshing: Boolean,
     noteList: List<Note>,
     isGridView: Boolean,
     onNoteListViewChanged: (isGridView: Boolean) -> Unit,
     onNoteClick: (String) -> Unit,
-    onDeleteNote: (String) -> Unit
+    onDeleteNote: (String) -> Unit,
+    onRefreshNoteList: () -> Unit
 ) {
     Column {
         Row(
@@ -291,18 +303,21 @@ fun NoteListSuccess(
                     .padding(all = 12.dp) // ensure no extra padding
             )
         }
-        if(isGridView) {
-            NoteListGridAdaptive(
-                noteList = noteList,
-                onNoteClick = onNoteClick,
-                onDeleteNote = onDeleteNote
-            )
-        } else {
-            NoteList(
-                noteList = noteList,
-                onNoteClick = onNoteClick,
-                onDeleteNote = onDeleteNote
-            )
+
+        PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = onRefreshNoteList) {
+            if(isGridView) {
+                NoteListGridAdaptive(
+                    noteList = noteList,
+                    onNoteClick = onNoteClick,
+                    onDeleteNote = onDeleteNote
+                )
+            } else {
+                NoteList(
+                    noteList = noteList,
+                    onNoteClick = onNoteClick,
+                    onDeleteNote = onDeleteNote
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
+++ b/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
@@ -13,17 +13,22 @@ import com.noteapp.util.NoteConstant.ALL_NOTES_DELETED_MSG
 import com.noteapp.util.NoteConstant.EMPTY_STRING
 import com.noteapp.util.NoteConstant.GENERIC_ERROR
 import com.noteapp.util.NoteConstant.LONG_FOUR_HUNDRED
+import com.noteapp.util.NoteConstant.LONG_ONE_THOUSAND
 import com.noteapp.util.NoteConstant.NOTE_DELETED_MSG
 import com.noteapp.util.getFirestoreError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -38,13 +43,16 @@ class NoteListViewModel(
     private var _uiState = MutableStateFlow<NoteListUiState>(value = NoteListUiState.Loading)
     val uiState: StateFlow<NoteListUiState> = _uiState
 
+    private val _isRefreshing = MutableStateFlow(value = false)
+    val isRefreshing = _isRefreshing.asStateFlow()
+
     private val _snackBarEvent = MutableSharedFlow<String>()
     val snackBarEvent = _snackBarEvent.asSharedFlow()
 
     var searchQueryToShowInSearchBox by mutableStateOf(value = EMPTY_STRING)
     var searchQueryToPassInFirestoreApi = MutableStateFlow(value = EMPTY_STRING)
 
-    init {
+    fun observeNoteList() {
         viewModelScope.launch {
             searchQueryToPassInFirestoreApi
                 .debounce(timeoutMillis = LONG_FOUR_HUNDRED)
@@ -71,6 +79,37 @@ class NoteListViewModel(
                 .collect { noteList ->
                     _uiState.value = NoteListUiState.Success(noteList = noteList)
                 }
+        }
+    }
+
+    fun refreshNoteList() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            try {
+                val deferredNotes = async {
+                    // Use current search query for refresh
+                    val currentQuery = searchQueryToPassInFirestoreApi.value
+                    if (currentQuery.isEmpty()) {
+                        firestoreRepository.getAllNotes().first()
+                    } else {
+                        firestoreRepository.searchNoteByTitle(query = currentQuery).first()
+                    }
+                }
+                // Ensure at least 1 second for smooth UX
+                delay(timeMillis = LONG_ONE_THOUSAND)
+                val noteList = deferredNotes.await()
+                _uiState.value = NoteListUiState.Success(noteList = noteList)
+            } catch (ex: Exception) {
+                if (ex is CancellationException) throw ex
+                val message = if (ex is FirebaseFirestoreException) {
+                    getFirestoreError(firestoreException = ex)
+                } else {
+                    GENERIC_ERROR
+                }
+                _uiState.value = NoteListUiState.Error(message)
+            } finally {
+                _isRefreshing.value = false
+            }
         }
     }
 

--- a/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
+++ b/app/src/main/java/com/noteapp/presentation/viewmodel/NoteListViewModel.kt
@@ -18,6 +18,7 @@ import com.noteapp.util.NoteConstant.NOTE_DELETED_MSG
 import com.noteapp.util.getFirestoreError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -52,8 +53,11 @@ class NoteListViewModel(
     var searchQueryToShowInSearchBox by mutableStateOf(value = EMPTY_STRING)
     var searchQueryToPassInFirestoreApi = MutableStateFlow(value = EMPTY_STRING)
 
+    private var observeJob: Job? = null
+
     fun observeNoteList() {
-        viewModelScope.launch {
+        if (observeJob?.isActive == true) return
+        observeJob = viewModelScope.launch {
             searchQueryToPassInFirestoreApi
                 .debounce(timeoutMillis = LONG_FOUR_HUNDRED)
                 .distinctUntilChanged()

--- a/app/src/main/java/com/noteapp/util/NoteConstant.kt
+++ b/app/src/main/java/com/noteapp/util/NoteConstant.kt
@@ -30,6 +30,7 @@ object NoteConstant {
     // Long
     const val LONG_FIFTY = 50L
     const val LONG_FOUR_HUNDRED = 400L
+    const val LONG_ONE_THOUSAND = 1000L
 
     // Rest
     const val EMPTY_STRING = ""


### PR DESCRIPTION
Introduced a pull-to-refresh feature on the note list screen.

- Added a `refreshNoteList()` function to the `NoteListViewModel` to handle the refresh logic, including a minimum 1-second delay for a smoother user experience.
- Implemented `PullToRefreshBox` in `NoteListScreen` to wrap the note list.
- Renamed the `init` block in `NoteListViewModel` to `observeNoteList()` and called it from a `LaunchedEffect` in the UI to start listening for note changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-to-refresh on the note list with real-time refresh indicator and explicit refresh action.
  * Continuous note-list observation starts when the screen appears to keep the list up to date.

* **Behavioral Changes**
  * Refresh enforces a brief UX delay and integrates with existing loading/error states.

* **Chores**
  * Added a small timing constant used by the refresh flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->